### PR TITLE
package: Add nyc dependency and a coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ npm-debug.log
 node_modules
 test/sandbox
 coverage
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "sl-registry": "bin/sl-registry.js"
   },
   "scripts": {
+    "coverage": "nyc npm test",
     "pretest": "jshint .",
     "test": "mocha"
   },
@@ -44,6 +45,7 @@
     "mocha": "^2.2.4",
     "must": "^0.12.0",
     "nexpect": "^0.5.0",
+    "nyc": "^3.2.2",
     "sinopia": "^1.2.1"
   }
 }


### PR DESCRIPTION
This serves as a flag for our CI build-framework to use `nyc` instead of `istanbul` for computing code coverage, see https://github.com/strongloop-internal/build-framework/pull/10.

Connect to strongloop-internal/scrum-loopback#469

/to @rmg please review

Current code coverage report:

```
---------------------|----------|----------|----------|----------|----------------|
File                 |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------------|----------|----------|----------|----------|----------------|
 bin/                |    69.23 |       70 |      100 |    69.23 |                |
  sl-registry.js     |    69.23 |       70 |      100 |    69.23 |... 35,36,41,42 |
 lib/                |    81.91 |       80 |    94.74 |    81.62 |                |
  exec-npm.js        |      100 |      100 |      100 |      100 |                |
  help.js            |        4 |      100 |        0 |        4 |... 22,23,24,25 |
  index.js           |      100 |      100 |      100 |      100 |                |
  quote-arg.js       |       50 |       25 |      100 |       50 |          4,5,7 |
  registry-config.js |      100 |    92.31 |      100 |      100 |                |
  spawn-npm-login.js |    82.61 |     87.5 |      100 |    82.61 |    25,26,27,28 |
  storage.js         |       95 |       75 |    92.86 |    94.83 |       29,30,86 |
 lib/commands/       |    98.82 |    90.57 |      100 |     98.8 |                |
  add.js             |      100 |      100 |      100 |      100 |                |
  list.js            |      100 |      100 |      100 |      100 |                |
  promote.js         |    98.82 |    86.21 |      100 |     98.8 |            121 |
  remove.js          |       95 |     87.5 |      100 |       95 |             27 |
  use.js             |      100 |      100 |      100 |      100 |                |
---------------------|----------|----------|----------|----------|----------------|
All files            |    88.51 |    84.69 |    96.83 |    88.36 |                |
---------------------|----------|----------|----------|----------|----------------|
```